### PR TITLE
fix(ci): Disable semantic-release build command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ omit = [
 ]
 
 [tool.semantic_release]
-build_command = "uv build"
+build_command = false
 major_on_zero = true
 tag_format = "v{version}"
 commit_message = "chore(release): v{version} [skip ci]"


### PR DESCRIPTION
The 'uv' command was not found in the semantic-release action's environment, causing the release workflow to fail. This change disables the build step within semantic-release, as the build is already handled by a separate step in the 'release.yml' workflow.