### PR TITLE
docs(release): Add PyPI publishing instructions to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ omit = [
 ]
 
 [tool.semantic_release]
-build_command = false
+# Configuration for PyPI publishing:
+# If python-semantic-release is used to publish to PyPI, uncomment and configure the following:
+# build_command = "uv build"
+# upload_to_pypi = true
 major_on_zero = true
 tag_format = "v{version}"
 commit_message = "chore(release): v{version} [skip ci]"


### PR DESCRIPTION
Removed the build_command from semantic-release configuration and added comments explaining how to configure PyPI publishing, including build_command and upload_to_pypi.