### PR TITLE
feat(ci): Disable build and publish steps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,15 +43,15 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         root_options: "--strict --verbose"
         
-    - name: Build package
-      if: steps.release.outputs.released == 'true'
-      run: uv build
+    # - name: Build package
+    #   if: steps.release.outputs.released == 'true'
+    #   run: uv build
 
-    - name: Publish to PyPI
-      if: steps.release.outputs.released == 'true'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        # Uncomment when you're ready to publish to PyPI
-        # password: ${{ secrets.PYPI_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/  # Test PyPI for now
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    # - name: Publish to PyPI
+    #   if: steps.release.outputs.released == 'true'
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     # Uncomment when you're ready to publish to PyPI
+    #     # password: ${{ secrets.PYPI_API_TOKEN }}
+    #     repository-url: https://test.pypi.org/legacy/  # Test PyPI for now
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
Commented out the 'Build package' and 'Publish to PyPI' steps in the release workflow as they are not currently needed and were causing errors.